### PR TITLE
 Add FontUtils to sample package for cross-platform testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .DS_Store
+.build
+.swiftpm

--- a/README.md
+++ b/README.md
@@ -160,7 +160,8 @@ The workflow generates coverage tables with automatic target detection:
 This repository includes a complete [sample Swift Package](sample/) with multiple targets to demonstrate the action's multi-target capabilities. The sample shows realistic coverage scenarios with:
 
 - **CoreLibrary** - Core mathematical operations (high coverage)
-- **UtilsLibrary** - Utility functions with dependencies (partial coverage)
-- **Comprehensive tests** - Demonstrating real-world testing patterns
+- **UtilsLibrary** - Utility functions with UIKit/AppKit dependencies (partial coverage)
+- **Cross-platform code** - Demonstrates conditional compilation for iOS/macOS frameworks
+- **Comprehensive tests** - Real-world testing patterns with platform-specific APIs
 
 See the [sample README](sample/README.md) for details.

--- a/sample/README.md
+++ b/sample/README.md
@@ -13,6 +13,7 @@ This is a sample Swift Package with **two targets** to demonstrate the Swift Cov
 2. **UtilsLibrary** - Utility functions that depend on CoreLibrary
    - `StringUtils.swift` - String manipulation utilities
    - `ArrayUtils.swift` - Array processing utilities
+   - `FontUtils.swift` - Cross-platform font utilities (iOS/macOS)
 
 ### Test Coverage
 
@@ -48,4 +49,6 @@ This sample demonstrates:
 - ✅ Proper target name extraction from file paths
 - ✅ Individual coverage calculation per target
 - ✅ Cross-target dependencies (UtilsLibrary uses CoreLibrary)
+- ✅ Cross-platform compatibility (iOS/macOS) with conditional compilation
+- ✅ Real-world Swift Testing scenarios with platform-specific code
 - ✅ Realistic partial coverage scenarios

--- a/sample/README.md
+++ b/sample/README.md
@@ -19,8 +19,8 @@ This is a sample Swift Package with **two targets** to demonstrate the Swift Cov
 
 The tests are intentionally **incomplete** to demonstrate partial coverage:
 
-- **CoreLibrary**: ~75% coverage (some edge cases not tested)
-- **UtilsLibrary**: ~60% coverage (some functions not tested)
+- **CoreLibrary**: ~90% coverage (most functions tested)
+- **UtilsLibrary**: ~65% coverage (some functions not tested, demonstrates mixed coverage)
 
 ## Expected Coverage Report
 
@@ -31,8 +31,8 @@ When the action runs, you should see output like:
 
 |   №  | Name | Executable Lines | Coverage |
 |:----:|------|-----------------:|---------:|
-| 1 | CoreLibrary | 45 | **76.5%** |
-| 2 | UtilsLibrary | 38 | **62.1%** |
+| 1 | CoreLibrary | 58 | **89.66%** |
+| 2 | UtilsLibrary | 77 | **49.35%** |
 ```
 
 ## Running Tests
@@ -49,6 +49,6 @@ This sample demonstrates:
 - ✅ Proper target name extraction from file paths
 - ✅ Individual coverage calculation per target
 - ✅ Cross-target dependencies (UtilsLibrary uses CoreLibrary)
-- ✅ Cross-platform compatibility (iOS/macOS) with conditional compilation
-- ✅ Real-world Swift Testing scenarios with platform-specific code
+- ✅ Cross-platform compatibility (iOS/macOS) with UIKit/AppKit conditional compilation
+- ✅ Real-world Swift Testing scenarios with platform-specific framework dependencies
 - ✅ Realistic partial coverage scenarios

--- a/sample/Sources/UtilsLibrary/FontUtils.swift
+++ b/sample/Sources/UtilsLibrary/FontUtils.swift
@@ -8,7 +8,7 @@ import AppKit
 public typealias PlatformFont = NSFont
 #endif
 
-/// Cross-platform font utilities for iOS and macOS
+/// Simple cross-platform font utilities for iOS and macOS
 public struct FontUtils {
 
     public init() {}
@@ -24,57 +24,9 @@ public struct FontUtils {
         #endif
     }
 
-    /// Creates a bold system font with the specified size
-    public func boldSystemFont(size: CGFloat) -> PlatformFont? {
-        #if canImport(UIKit)
-        return UIFont.boldSystemFont(ofSize: size)
-        #elseif canImport(AppKit)
-        return NSFont.boldSystemFont(ofSize: size)
-        #else
-        return nil
-        #endif
-    }
-
     /// Gets the font size from a platform font
     public func fontSize(from font: PlatformFont) -> CGFloat {
         return font.pointSize
-    }
-
-    /// Checks if a font is bold
-    public func isBold(_ font: PlatformFont) -> Bool {
-        #if canImport(UIKit)
-        let traits = font.fontDescriptor.symbolicTraits
-        return traits.contains(.traitBold)
-        #elseif canImport(AppKit)
-        let traits = font.fontDescriptor.symbolicTraits
-        return traits.contains(.bold)
-        #else
-        return false
-        #endif
-    }
-
-    /// Gets the font family name
-    public func familyName(from font: PlatformFont) -> String? {
-        return font.familyName
-    }
-
-    /// Compares two fonts for equality based on family name and size
-    public func areEqual(_ font1: PlatformFont, _ font2: PlatformFont) -> Bool {
-        guard let family1 = font1.familyName, let family2 = font2.familyName else {
-            return false
-        }
-        return family1 == family2 && font1.pointSize == font2.pointSize
-    }
-
-    /// Scales a font to a new size
-    public func scale(_ font: PlatformFont, to newSize: CGFloat) -> PlatformFont? {
-        #if canImport(UIKit)
-        return font.withSize(newSize)
-        #elseif canImport(AppKit)
-        return NSFont(descriptor: font.fontDescriptor, size: newSize)
-        #else
-        return nil
-        #endif
     }
 
     /// Validates if a font size is within reasonable bounds

--- a/sample/Sources/UtilsLibrary/FontUtils.swift
+++ b/sample/Sources/UtilsLibrary/FontUtils.swift
@@ -1,0 +1,106 @@
+import Foundation
+
+#if canImport(UIKit)
+import UIKit
+public typealias PlatformFont = UIFont
+#elseif canImport(AppKit)
+import AppKit
+public typealias PlatformFont = NSFont
+#endif
+
+/// Cross-platform font utilities for iOS and macOS
+public struct FontUtils {
+
+    public init() {}
+
+    /// Creates a system font with the specified size
+    public func systemFont(size: CGFloat) -> PlatformFont? {
+        #if canImport(UIKit)
+        return UIFont.systemFont(ofSize: size)
+        #elseif canImport(AppKit)
+        return NSFont.systemFont(ofSize: size)
+        #else
+        return nil
+        #endif
+    }
+
+    /// Creates a bold system font with the specified size
+    public func boldSystemFont(size: CGFloat) -> PlatformFont? {
+        #if canImport(UIKit)
+        return UIFont.boldSystemFont(ofSize: size)
+        #elseif canImport(AppKit)
+        return NSFont.boldSystemFont(ofSize: size)
+        #else
+        return nil
+        #endif
+    }
+
+    /// Gets the font size from a platform font
+    public func fontSize(from font: PlatformFont) -> CGFloat {
+        return font.pointSize
+    }
+
+    /// Checks if a font is bold
+    public func isBold(_ font: PlatformFont) -> Bool {
+        #if canImport(UIKit)
+        let traits = font.fontDescriptor.symbolicTraits
+        return traits.contains(.traitBold)
+        #elseif canImport(AppKit)
+        let traits = font.fontDescriptor.symbolicTraits
+        return traits.contains(.bold)
+        #else
+        return false
+        #endif
+    }
+
+    /// Gets the font family name
+    public func familyName(from font: PlatformFont) -> String? {
+        return font.familyName
+    }
+
+    /// Compares two fonts for equality based on family name and size
+    public func areEqual(_ font1: PlatformFont, _ font2: PlatformFont) -> Bool {
+        guard let family1 = font1.familyName, let family2 = font2.familyName else {
+            return false
+        }
+        return family1 == family2 && font1.pointSize == font2.pointSize
+    }
+
+    /// Scales a font to a new size
+    public func scale(_ font: PlatformFont, to newSize: CGFloat) -> PlatformFont? {
+        #if canImport(UIKit)
+        return font.withSize(newSize)
+        #elseif canImport(AppKit)
+        return NSFont(descriptor: font.fontDescriptor, size: newSize)
+        #else
+        return nil
+        #endif
+    }
+
+    /// Validates if a font size is within reasonable bounds
+    public func isValidFontSize(_ size: CGFloat) -> Bool {
+        return size >= 6.0 && size <= 144.0
+    }
+
+    /// Gets the default font size for different text styles
+    public func defaultSize(for style: FontStyle) -> CGFloat {
+        switch style {
+        case .caption:
+            return 12.0
+        case .body:
+            return 17.0
+        case .headline:
+            return 22.0
+        case .title:
+            return 28.0
+        }
+    }
+}
+
+/// Common font styles
+public enum FontStyle {
+    case caption
+    case body
+    case headline
+    case title
+}

--- a/sample/Tests/UtilsLibraryTests/FontUtilsTests.swift
+++ b/sample/Tests/UtilsLibraryTests/FontUtilsTests.swift
@@ -14,59 +14,14 @@ struct FontUtilsTests {
         }
     }
 
-    @Test func testBoldSystemFont() {
-        let utils = FontUtils()
-        let font = utils.boldSystemFont(size: 18.0)
-
-        #expect(font != nil)
-        if let font = font {
-            #expect(utils.fontSize(from: font) == 18.0)
-            #expect(utils.isBold(font) == true)
-        }
-    }
-
     @Test func testFontSizeExtraction() {
         let utils = FontUtils()
-        let font = utils.systemFont(size: 24.0)
+        let font = utils.systemFont(size: 18.0)
 
         #expect(font != nil)
         if let font = font {
-            #expect(utils.fontSize(from: font) == 24.0)
-        }
-    }
-
-    @Test func testFontComparison() {
-        let utils = FontUtils()
-        let font1 = utils.systemFont(size: 16.0)
-        let font2 = utils.systemFont(size: 16.0)
-        let font3 = utils.systemFont(size: 20.0)
-
-        #expect(font1 != nil)
-        #expect(font2 != nil)
-        #expect(font3 != nil)
-
-        if let font1 = font1, let font2 = font2, let font3 = font3 {
-            #expect(utils.areEqual(font1, font2) == true)
-            #expect(utils.areEqual(font1, font3) == false)
-        }
-    }
-
-    @Test func testFontScaling() {
-        let utils = FontUtils()
-        let originalFont = utils.systemFont(size: 16.0)
-
-        #expect(originalFont != nil)
-        if let originalFont = originalFont {
-            let scaledFont = utils.scale(originalFont, to: 20.0)
-            #expect(scaledFont != nil)
-
-            if let scaledFont = scaledFont {
-                #expect(utils.fontSize(from: scaledFont) == 20.0)
-                // Compare family names handling optionals
-                let originalFamily = utils.familyName(from: originalFont)
-                let scaledFamily = utils.familyName(from: scaledFont)
-                #expect(originalFamily == scaledFamily)
-            }
+            let actualSize = utils.fontSize(from: font)
+            #expect(actualSize == 18.0)
         }
     }
 
@@ -86,18 +41,6 @@ struct FontUtilsTests {
         #expect(utils.defaultSize(for: .body) == 17.0)
         #expect(utils.defaultSize(for: .headline) == 22.0)
         #expect(utils.defaultSize(for: .title) == 28.0)
-    }
-
-    @Test func testFamilyName() throws {
-        let utils = FontUtils()
-        let font = utils.systemFont(size: 16.0)
-
-        #expect(font != nil)
-        if let font = font {
-            let familyName = try #require(utils.familyName(from: font))
-            #expect(!familyName.isEmpty)
-            // System font family name varies by platform but should always be non-empty
-        }
     }
 
     // Note: Not testing all edge cases to maintain partial coverage

--- a/sample/Tests/UtilsLibraryTests/FontUtilsTests.swift
+++ b/sample/Tests/UtilsLibraryTests/FontUtilsTests.swift
@@ -1,0 +1,105 @@
+import Testing
+@testable import UtilsLibrary
+
+#if canImport(UIKit) || canImport(AppKit)
+struct FontUtilsTests {
+
+    @Test func testSystemFont() {
+        let utils = FontUtils()
+        let font = utils.systemFont(size: 16.0)
+
+        #expect(font != nil)
+        if let font = font {
+            #expect(utils.fontSize(from: font) == 16.0)
+        }
+    }
+
+    @Test func testBoldSystemFont() {
+        let utils = FontUtils()
+        let font = utils.boldSystemFont(size: 18.0)
+
+        #expect(font != nil)
+        if let font = font {
+            #expect(utils.fontSize(from: font) == 18.0)
+            #expect(utils.isBold(font) == true)
+        }
+    }
+
+    @Test func testFontSizeExtraction() {
+        let utils = FontUtils()
+        let font = utils.systemFont(size: 24.0)
+
+        #expect(font != nil)
+        if let font = font {
+            #expect(utils.fontSize(from: font) == 24.0)
+        }
+    }
+
+    @Test func testFontComparison() {
+        let utils = FontUtils()
+        let font1 = utils.systemFont(size: 16.0)
+        let font2 = utils.systemFont(size: 16.0)
+        let font3 = utils.systemFont(size: 20.0)
+
+        #expect(font1 != nil)
+        #expect(font2 != nil)
+        #expect(font3 != nil)
+
+        if let font1 = font1, let font2 = font2, let font3 = font3 {
+            #expect(utils.areEqual(font1, font2) == true)
+            #expect(utils.areEqual(font1, font3) == false)
+        }
+    }
+
+    @Test func testFontScaling() {
+        let utils = FontUtils()
+        let originalFont = utils.systemFont(size: 16.0)
+
+        #expect(originalFont != nil)
+        if let originalFont = originalFont {
+            let scaledFont = utils.scale(originalFont, to: 20.0)
+            #expect(scaledFont != nil)
+
+            if let scaledFont = scaledFont {
+                #expect(utils.fontSize(from: scaledFont) == 20.0)
+                // Compare family names handling optionals
+                let originalFamily = utils.familyName(from: originalFont)
+                let scaledFamily = utils.familyName(from: scaledFont)
+                #expect(originalFamily == scaledFamily)
+            }
+        }
+    }
+
+    @Test func testValidFontSize() {
+        let utils = FontUtils()
+
+        #expect(utils.isValidFontSize(12.0) == true)
+        #expect(utils.isValidFontSize(5.0) == false)  // Too small
+        #expect(utils.isValidFontSize(150.0) == false)  // Too large
+        #expect(utils.isValidFontSize(72.0) == true)
+    }
+
+    @Test func testDefaultFontSizes() {
+        let utils = FontUtils()
+
+        #expect(utils.defaultSize(for: .caption) == 12.0)
+        #expect(utils.defaultSize(for: .body) == 17.0)
+        #expect(utils.defaultSize(for: .headline) == 22.0)
+        #expect(utils.defaultSize(for: .title) == 28.0)
+    }
+
+    @Test func testFamilyName() throws {
+        let utils = FontUtils()
+        let font = utils.systemFont(size: 16.0)
+
+        #expect(font != nil)
+        if let font = font {
+            let familyName = try #require(utils.familyName(from: font))
+            #expect(!familyName.isEmpty)
+            // System font family name varies by platform but should always be non-empty
+        }
+    }
+
+    // Note: Not testing all edge cases to maintain partial coverage
+}
+#endif


### PR DESCRIPTION
Added cross-platform font utilities to the sample package to demonstrate that the Swift Coverage Action works with real iOS/macOS code that uses UIKit/AppKit frameworks.